### PR TITLE
Normalize classifier booleans

### DIFF
--- a/Extension/workit.js
+++ b/Extension/workit.js
@@ -433,12 +433,20 @@ async function apiCall(prompt) {
 
 
     const data = await response.json();
-    const generatedText = data?.candidates?.[0]?.content?.parts?.[0]?.text.toLowerCase();
+    const rawText = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+    const generatedText = typeof rawText === 'string' ? rawText.toLowerCase() : "";
     console.log(generatedText)
+
+    if (!generatedText) {
+        return [];
+    }
+
     const match = generatedText.match(/\[.*\]/s);
     const array = match ? JSON.parse(match[0].replace(/false/g, 'false').replace(/true/g, 'true')) : [];
 
-    return array;
+    return Array.isArray(array)
+        ? array.map(value => value === true || value === 'true')
+        : [];
 }
 
 const cssURL = chrome.runtime.getURL("inject.css");


### PR DESCRIPTION
## Summary
- guard against missing model output before applying the boolean array regex
- normalize the parsed response into strict booleans so downstream checks work reliably

## Testing
- node - <<'NODE'
const rawText = "[true, false, true, false]";
const generatedText = typeof rawText === 'string' ? rawText.toLowerCase() : "";
if (!generatedText) {
    console.log('empty generated text');
} else {
    const match = generatedText.match(/\[.*\]/s);
    const array = match ? JSON.parse(match[0].replace(/false/g, 'false').replace(/true/g, 'true')) : [];
    const normalized = Array.isArray(array)
        ? array.map(value => value === true || value === 'true')
        : [];
    console.log(normalized);
    console.log(normalized.map(value => typeof value));
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cc473eb58c832c8fe1a9633e1d6b56